### PR TITLE
Fix grade 3 multiplication app IDs and paths

### DIFF
--- a/app_data.json
+++ b/app_data.json
@@ -99,9 +99,9 @@
       "units": [
       {"name": "１　　九九の表とかけ算",
       "apps": [
-        {"id": "kakezan-10s-challenge", "title": "10のかけ算", "path": "3nen/1_kuku_hyo_kakezan/01_10nokakezan.html"},
-        {"id": "kakezan-10s-challenge", "title": "0のかけ算", "path": "3nen/1_kuku_hyo_kakezan02_0nokakezan.html"},
-        {"id": "kakezan-10s-challenge", "title": "□のかけ算", "path": "3nen/1_kuku_hyo_kakezan03_shikaku_kakezan.html"}
+        {"id": "kakezan-10", "title": "10のかけ算", "path": "3nen/1_kuku_hyo_kakezan/01_10nokakezan.html"},
+        {"id": "kakezan-0", "title": "0のかけ算", "path": "3nen/1_kuku_hyo_kakezan/02_0nokakezan.html"},
+        {"id": "kakezan-shikaku", "title": "□のかけ算", "path": "3nen/1_kuku_hyo_kakezan/03_shikaku_kakezan.html"}
       ]
     },
       {"name":"２　　わり算",


### PR DESCRIPTION
## Summary
- Fix incorrect paths for grade 3 "九九の表とかけ算" apps
- Give each multiplication app a unique ID for independent progress tracking

## Testing
- `node - <<'NODE'
const fs=require('fs');
const data=JSON.parse(fs.readFileSync('app_data.json','utf8'));
const grade3=data.find(g=>g.grade==='3年');
const unit=grade3.units.find(u=>u.name.includes('九九の表とかけ算'));
const apps=unit.apps;
apps.forEach(app=> console.log(app.path, fs.existsSync(app.path)));
const storage={};
apps.forEach((app,i)=> storage[`${app.id}_highScore`]=String(10+i));
apps.forEach(app=> console.log(app.id, storage[`${app.id}_highScore`]));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_6896336737888323a77e4170cbbd7752