### PR TITLE
refactor: use APP_ID constants for second-grade drills

### DIFF
--- a/2nen/10_kakezan1/10kuku_5dan_junban.html
+++ b/2nen/10_kakezan1/10kuku_5dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-5dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-5dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/20kuku_5dan_barabara.html
+++ b/2nen/10_kakezan1/20kuku_5dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-5dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-5dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/30kuku_2dan_junban.html
+++ b/2nen/10_kakezan1/30kuku_2dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-2dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-2dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/40kuku_2dan_barabara.html
+++ b/2nen/10_kakezan1/40kuku_2dan_barabara.html
@@ -244,19 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-2dan-barabara_"; 
-    
-    // ★以下の行を削除しました。これらの情報はインデックスページで管理します。
-    // const APP_GRADE = '2年';
-    // const APP_CATEGORY = 'かけ算';
-
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-2dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/50kuku_3dan_junban.html
+++ b/2nen/10_kakezan1/50kuku_3dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-3dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-3dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/60kuku_3dan_barabara.html
+++ b/2nen/10_kakezan1/60kuku_3dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-3dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-3dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/70kuku_4dan_junban.html
+++ b/2nen/10_kakezan1/70kuku_4dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-4dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-4dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/80kuku_4dan_barabara.html
+++ b/2nen/10_kakezan1/80kuku_4dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-4dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-4dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/10_kakezan1/90kuku_2345dan_random.html
+++ b/2nen/10_kakezan1/90kuku_2345dan_random.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-2345dan-random_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-2345dan-random";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 10; // 問題数を10問に設定
     const TIME_LIMIT    = NUM_QUESTIONS * 3; 

--- a/2nen/11_kakezan2/100kuku_1dan_barabara.html
+++ b/2nen/11_kakezan2/100kuku_1dan_barabara.html
@@ -244,14 +244,13 @@
   </div>
 
   <script>
-    const APP_NS = "kuku-1dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    const APP_ID = "kuku-1dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/10kuku_6dan_junban.html
+++ b/2nen/11_kakezan2/10kuku_6dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-6dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-6dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/110kuku_16789dan_random.html
+++ b/2nen/11_kakezan2/110kuku_16789dan_random.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "23kuku_16789dan_random_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "23kuku_16789dan_random";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 10; // 問題数を10問に設定
     const TIME_LIMIT    = NUM_QUESTIONS * 3; 

--- a/2nen/11_kakezan2/120kuku_10mondai.html
+++ b/2nen/11_kakezan2/120kuku_10mondai.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-10mondai_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-10mondai";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 10; // ★問題数を10問に設定
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/130kuku_81mondai.html
+++ b/2nen/11_kakezan2/130kuku_81mondai.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-81mondai_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-81mondai";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 81; // ★問題数を81問に設定
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 81問なら 243秒

--- a/2nen/11_kakezan2/20kuku_6dan_barabara.html
+++ b/2nen/11_kakezan2/20kuku_6dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-6dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-6dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/30kuku_7dan_junban.html
+++ b/2nen/11_kakezan2/30kuku_7dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-7dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-7dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/40kuku_7dan_barabara.html
+++ b/2nen/11_kakezan2/40kuku_7dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-7dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-7dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/50kuku_8dan_junban.html
+++ b/2nen/11_kakezan2/50kuku_8dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-8dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-8dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/60kuku_8dan_barabara.html
+++ b/2nen/11_kakezan2/60kuku_8dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-8dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-8dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/70kuku_9dan_junban.html
+++ b/2nen/11_kakezan2/70kuku_9dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-9dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-9dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/80kuku_9dan_barabara.html
+++ b/2nen/11_kakezan2/80kuku_9dan_barabara.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-9dan-barabara_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-9dan-barabara";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒

--- a/2nen/11_kakezan2/90kuku_1dan_junban.html
+++ b/2nen/11_kakezan2/90kuku_1dan_junban.html
@@ -244,15 +244,14 @@
   </div>
 
   <script>
-    // ★ここを変更！JSONで定義するIDに合わせる（末尾にアンダースコア'_'）
-    const APP_NS = "kuku-1dan-junban_"; 
-    
-    const KEY_HS             = APP_NS + "highScore"; 
-    const KEY_HISTORY        = APP_NS + "history"; 
-    const KEY_CLEAR          = APP_NS + "clearCount"; 
-    const KEY_MONTHLY_PREFIX = APP_NS + "monthlyClear-"; 
-    const KEY_DAILY_PREFIX   = APP_NS + "dailyClear-"; 
-    const KEY_OVERALL_STATUS = APP_NS + "overallStatus"; 
+    // ★ここを変更！JSONで定義するIDに合わせる
+    const APP_ID = "kuku-1dan-junban";
+    const KEY_HS             = `${APP_ID}:hs`;
+    const KEY_HISTORY        = `${APP_ID}:history`;
+    const KEY_CLEAR          = `${APP_ID}:clearCount`;
+    const KEY_MONTHLY_PREFIX = `${APP_ID}:monthlyClear-`;
+    const KEY_DAILY_PREFIX   = `${APP_ID}:dailyClear-`;
+    const KEY_OVERALL_STATUS = `${APP_ID}:status`;
 
     const NUM_QUESTIONS = 9; 
     const TIME_LIMIT    = NUM_QUESTIONS * 3; // 10問なら 30秒


### PR DESCRIPTION
## Summary
- replace `APP_NS` with `APP_ID` constants for 2nd grade multiplication drills
- derive key names from `APP_ID` using colon-separated localStorage keys

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a0b1ab28483238fb609af6da037b8