### PR TITLE
Fix second-grade multiplication drill IDs

### DIFF
--- a/2nen/10_kakezan1/90kuku_2345dan_random.html
+++ b/2nen/10_kakezan1/90kuku_2345dan_random.html
@@ -48,7 +48,7 @@
   <script src="common.js"></script>
   
   <!-- 3. このページで表示したいドリルの設定ファイル -->
-  <script src="configs/kuku_5234dan_random.js"></script>
+  <script src="configs/kuku_2345dan_random.js"></script>
   
 </body>
 </html>

--- a/2nen/10_kakezan1/configs/kuku_2345dan_random.js
+++ b/2nen/10_kakezan1/configs/kuku_2345dan_random.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-2345dan-random-v1', 
+  appId: 'kuku-2345dan-random',
   title: '二～五の段の九九（ランダム）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_2dan_barabara.js
+++ b/2nen/10_kakezan1/configs/kuku_2dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-2dan-barabara-v1', 
+  appId: 'kuku-2dan-barabara',
   title: '二の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_2dan_junban.js
+++ b/2nen/10_kakezan1/configs/kuku_2dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-2dan-junban-v1', 
+  appId: 'kuku-2dan-junban',
   title: '二の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_3dan_barabara.js
+++ b/2nen/10_kakezan1/configs/kuku_3dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-3dan-barabara-v1', 
+  appId: 'kuku-3dan-barabara',
   title: '三の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_3dan_junban.js
+++ b/2nen/10_kakezan1/configs/kuku_3dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-3dan-junban-v1', 
+  appId: 'kuku-3dan-junban',
   title: '三の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_4dan_barabara.js
+++ b/2nen/10_kakezan1/configs/kuku_4dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-4dan-barabara-v1', 
+  appId: 'kuku-4dan-barabara',
   title: '四の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_4dan_junban.js
+++ b/2nen/10_kakezan1/configs/kuku_4dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-4dan-junban-v1', 
+  appId: 'kuku-4dan-junban',
   title: '四の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_5dan_barabara.js
+++ b/2nen/10_kakezan1/configs/kuku_5dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-5dan-barabara-v1', 
+  appId: 'kuku-5dan-barabara',
   title: '五の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/10_kakezan1/configs/kuku_5dan_junban.js
+++ b/2nen/10_kakezan1/configs/kuku_5dan_junban.js
@@ -7,7 +7,7 @@
 const quizConfig = {
   // 1. アプリの基本情報
   // ローカルストレージで他のアプリと区別するためのID
-  appId: 'kuku-5dan-junban-v3', 
+  appId: 'kuku-5dan-junban',
   
   // ブラウザのタブや画面に表示されるタイトル
   title: '五の段の九九（じゅんばん）',

--- a/2nen/11_kakezan2/kuku_6dan_barabara.js
+++ b/2nen/11_kakezan2/kuku_6dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-6dan-barabara-v1', 
+  appId: 'kuku-6dan-barabara',
   title: '六の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_6dan_junban.js
+++ b/2nen/11_kakezan2/kuku_6dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-6dan-junban-v1', 
+  appId: 'kuku-6dan-junban',
   title: '六の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_7dan_barabara.js
+++ b/2nen/11_kakezan2/kuku_7dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-7dan-barabara-v1', 
+  appId: 'kuku-7dan-barabara',
   title: '七の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_7dan_junban.js
+++ b/2nen/11_kakezan2/kuku_7dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-7dan-junban-v1', 
+  appId: 'kuku-7dan-junban',
   title: '七の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_8dan_barabara.js
+++ b/2nen/11_kakezan2/kuku_8dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-8dan-barabara-v1', 
+  appId: 'kuku-8dan-barabara',
   title: '八の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_8dan_junban.js
+++ b/2nen/11_kakezan2/kuku_8dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-8dan-junban-v1', 
+  appId: 'kuku-8dan-junban',
   title: '八の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_9dan_barabara.js
+++ b/2nen/11_kakezan2/kuku_9dan_barabara.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-9dan-barabara-v1', 
+  appId: 'kuku-9dan-barabara',
   title: '九の段の九九（ばらばら）',
 
   // 2. 問題を生成する関数

--- a/2nen/11_kakezan2/kuku_9dan_junban.js
+++ b/2nen/11_kakezan2/kuku_9dan_junban.js
@@ -4,7 +4,7 @@
 
 const quizConfig = {
   // 1. アプリの基本情報
-  appId: 'kuku-9dan-junban-v1', 
+  appId: 'kuku-9dan-junban',
   title: '九の段の九九（じゅんばん）',
 
   // 2. 問題を生成する関数

--- a/app_data.json
+++ b/app_data.json
@@ -483,7 +483,7 @@
           {
             "id": "kuku-8dan-junban",
             "title": "八の段の九九（じゅんばん）",
-            "path": "2nen/11_kakezan2/50uku_8dan_junban.html"
+            "path": "2nen/11_kakezan2/50kuku_8dan_junban.html"
           },
           {
             "id": "kuku-8dan-barabara",
@@ -513,7 +513,7 @@
           {
             "id": "23kuku_16789dan_random",
             "title": "一、六、七、八、九段の九九",
-            "path": "2nen/11_kakezan2/110kuku_16789dan_random"
+            "path": "2nen/11_kakezan2/110kuku_16789dan_random.html"
           },
           {
             "id": "kuku-10mondai",


### PR DESCRIPTION
## Summary
- align drill configuration `appId`s with index IDs for second-grade multiplication units
- fix broken file paths and rename random drill to consistent 2345 naming

## Testing
- `ls 2nen/10_kakezan1/configs/*.js 2nen/11_kakezan2/kuku_*.js | while read f; do node --check "$f" && echo checked $f; done`
- `jq . app_data.json`

------
https://chatgpt.com/codex/tasks/task_e_68a0c825ef2c8323bc324482a0b53d71