### PR TITLE
Add clearCount/status storage for grade 1 drills

### DIFF
--- a/1nen/08_kazu_shirabe/027_kazu_shirabe.html
+++ b/1nen/08_kazu_shirabe/027_kazu_shirabe.html
@@ -348,6 +348,8 @@
         function saveData() {
             const ls = localStorage;
             ls.setItem(`${config.appId}:total`, totalClearCount);
+            ls.setItem(`${config.appId}:clearCount`, totalClearCount);
+            ls.setItem(`${config.appId}:status`, "★★★★★");
             const todayKey = `${config.appId}:daily-${new Date().toISOString().slice(0, 10)}`;
             ls.setItem(todayKey, dailyCount);
             updateStatsDisplay();

--- a/1nen/09_10yori_ookii/35_10_to_ikutsu.html
+++ b/1nen/09_10yori_ookii/35_10_to_ikutsu.html
@@ -340,6 +340,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素取得
         const els = {
@@ -657,6 +659,8 @@
             // 合計クリア回数
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             // 本日クリア回数
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');

--- a/1nen/09_10yori_ookii/37_kazu_no_sen.html
+++ b/1nen/09_10yori_ookii/37_kazu_no_sen.html
@@ -379,6 +379,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -643,6 +645,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/09_10yori_ookii/39_tashizan_hikizan.html
+++ b/1nen/09_10yori_ookii/39_tashizan_hikizan.html
@@ -347,6 +347,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -616,6 +618,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/10_nanji_nanjihan/45_nanji_nanjihan.html
+++ b/1nen/10_nanji_nanjihan/45_nanji_nanjihan.html
@@ -358,6 +358,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -662,6 +664,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/12_3kazu_keisan/55_3tsu_no_kazu.html
+++ b/1nen/12_3kazu_keisan/55_3tsu_no_kazu.html
@@ -347,6 +347,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -611,6 +613,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/12_3kazu_keisan/56_3tsu_no_hikizan.html
+++ b/1nen/12_3kazu_keisan/56_3tsu_no_hikizan.html
@@ -353,6 +353,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -627,6 +629,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/12_3kazu_keisan/58_3tsu_no_kongo.html
+++ b/1nen/12_3kazu_keisan/58_3tsu_no_kongo.html
@@ -355,6 +355,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -658,6 +660,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/13_tashizan2/63_sakuranbo_zan_1.html
+++ b/1nen/13_tashizan2/63_sakuranbo_zan_1.html
@@ -428,6 +428,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -847,6 +849,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/13_tashizan2/65_sakuranbo_zan_2.html
+++ b/1nen/13_tashizan2/65_sakuranbo_zan_2.html
@@ -446,6 +446,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -827,6 +829,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/13_tashizan2/66_11_no_card.html
+++ b/1nen/13_tashizan2/66_11_no_card.html
@@ -327,6 +327,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -535,6 +537,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/13_tashizan2/66_tashizan_card.html
+++ b/1nen/13_tashizan2/66_tashizan_card.html
@@ -386,6 +386,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -646,6 +648,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/15_hikizan2/79_sakuranbo_zan_3.html
+++ b/1nen/15_hikizan2/79_sakuranbo_zan_3.html
@@ -446,6 +446,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -830,6 +832,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/15_hikizan2/80_kurisagari_hikizan.html
+++ b/1nen/15_hikizan2/80_kurisagari_hikizan.html
@@ -373,6 +373,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -647,6 +649,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/15_hikizan2/82_9_no_card.html
+++ b/1nen/15_hikizan2/82_9_no_card.html
@@ -325,6 +325,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -543,6 +545,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/16_zero_keisan/88_0_no_tashizan.html
+++ b/1nen/16_zero_keisan/88_0_no_tashizan.html
@@ -375,6 +375,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -651,6 +653,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/16_zero_keisan/89_0_no_hikizan.html
+++ b/1nen/16_zero_keisan/89_0_no_hikizan.html
@@ -375,6 +375,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -647,6 +649,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/101_kazu_no_shikumi.html
+++ b/1nen/18_ookii_kazu/101_kazu_no_shikumi.html
@@ -356,6 +356,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -710,6 +712,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/103_kazu_no_junjo.html
+++ b/1nen/18_ookii_kazu/103_kazu_no_junjo.html
@@ -400,6 +400,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -702,6 +704,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/104_kazu_no_ookisa.html
+++ b/1nen/18_ookii_kazu/104_kazu_no_ookisa.html
@@ -293,6 +293,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM elements
         const els = {
@@ -510,6 +512,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/105_ato_ikutsu_de_100.html
+++ b/1nen/18_ookii_kazu/105_ato_ikutsu_de_100.html
@@ -431,6 +431,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         const els = {
             startArea: document.getElementById('start-area'),
@@ -682,6 +684,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/105_kazu_card_no_narabikata.html
+++ b/1nen/18_ookii_kazu/105_kazu_card_no_narabikata.html
@@ -411,6 +411,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         const els = {
             startArea: document.getElementById('start-area'),
@@ -724,6 +726,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/105_kazu_narabekae.html
+++ b/1nen/18_ookii_kazu/105_kazu_narabekae.html
@@ -323,6 +323,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         const els = {
             startArea: document.getElementById('start-area'),
@@ -581,6 +583,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/107_okane_no_dashikata.html
+++ b/1nen/18_ookii_kazu/107_okane_no_dashikata.html
@@ -544,6 +544,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         const els = {
             mainTitle: document.getElementById('main-title'),
@@ -775,6 +777,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;

--- a/1nen/18_ookii_kazu/109_nedan_yomi_quiz.html
+++ b/1nen/18_ookii_kazu/109_nedan_yomi_quiz.html
@@ -357,6 +357,8 @@
         const KEY_CLEAR = `${config.appId}:totalClear`;
         const KEY_DAILY_PREFIX = `${config.appId}:dailyClear_`;
         const KEY_HISTORY = `${config.appId}:history`;
+        const KEY_CLEAR_COUNT = `${config.appId}:clearCount`;
+        const KEY_STATUS = `${config.appId}:status`;
 
         // DOM要素
         const els = {
@@ -628,6 +630,8 @@
         function saveData(score, stars, elapsedSec) {
             const total = parseInt(localStorage.getItem(KEY_CLEAR) || 0) + 1;
             localStorage.setItem(KEY_CLEAR, total);
+            localStorage.setItem(KEY_CLEAR_COUNT, total);
+            localStorage.setItem(KEY_STATUS, stars);
 
             const todayKey = KEY_DAILY_PREFIX + new Date().toLocaleDateString('ja-JP');
             const daily = parseInt(localStorage.getItem(todayKey) || 0) + 1;


### PR DESCRIPTION
### Motivation
- The index needs per-app clear counts and star/status to display progress, so each drill must persist `${appId}:clearCount` and `${appId}:status` in localStorage.
- Many grade‑1 drills (units 8–18) only wrote `:totalClear`/`:total` and high score data, so the index could not read the new keys.
- `かずしらべ` needed to sync its perfect-clear logic to also update the `clearCount`/`status` keys so the index shows the correct stars on perfect clears.
- Keep changes minimal and backwards compatible by adding two new storage keys without altering scoring logic.

### Description
- Added `KEY_CLEAR_COUNT` and `KEY_STATUS` constants and calls to `localStorage.setItem(KEY_CLEAR_COUNT, total)` and `localStorage.setItem(KEY_STATUS, stars)` inside `saveData()` across the grade‑1 drills in units 8–18.
- Updated `1nen/08_kazu_shirabe/027_kazu_shirabe.html` to also write `${config.appId}:clearCount` and `${config.appId}:status` when a perfect clear occurs (status set to `"★★★★★"`).
- Changes were applied to the set of drill HTML files under `1nen/...` (25 files changed in the commit) and no scoring or display logic was otherwise modified.
- Implementation focuses on persisting the two keys so the site index can read `:clearCount` and `:status` per app.

### Testing
- Ran a discovery script against `app_data.json` to enumerate grade‑1 apps in units 8–18 and an initial grep that reported 26 files missing the new keys.
- Executed an automated insertion script to add `KEY_CLEAR_COUNT`/`KEY_STATUS` and `setItem` calls into the target files and applied a manual patch for the `かずしらべ` page, which ran without errors.
- Re-scans (`rg` and Python checks) reduced missing entries to a single file: `1nen/08_kazu_shirabe/035_10_to_ikutsu.html` (reported as missing), and `git commit` succeeded showing 25 files changed.
- No unit or UI tests were run beyond the repository scans and text-based verifications described above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f0207547c83238fb03557c1865386)